### PR TITLE
Feat fetch latest l1->l2 transactions

### DIFF
--- a/src/components/pages/home/latest-l1-l2-transactions.tsx
+++ b/src/components/pages/home/latest-l1-l2-transactions.tsx
@@ -9,7 +9,7 @@ import {
   CardTitle,
   CardFooter,
 } from "@/components/ui/card";
-import { l1Chain, l2Chain } from "@/lib/chains";
+import { l1Chain } from "@/lib/chains";
 
 const LatestL1L2Transaction = ({
   transaction,
@@ -48,7 +48,7 @@ const LatestL1L2Transaction = ({
           L2 Tx#{" "}
           <Link
             className="max-w-28 truncate text-primary hover:brightness-150 md:max-w-48 xl:max-w-28"
-            href={`${l2Chain.blockExplorers.default.url}/tx/${transaction.l2Hash}`}
+            href={`/tx/${transaction.l2Hash}`}
           >
             {transaction.l2Hash}
           </Link>

--- a/src/components/pages/home/latest-l1-l2-transactions.tsx
+++ b/src/components/pages/home/latest-l1-l2-transactions.tsx
@@ -9,7 +9,7 @@ import {
   CardTitle,
   CardFooter,
 } from "@/components/ui/card";
-import { l1Chain,l2Chain } from "@/lib/chains";
+import { l1Chain, l2Chain } from "@/lib/chains";
 
 const LatestL1L2Transaction = ({
   transaction,

--- a/src/components/pages/home/latest-l1-l2-transactions.tsx
+++ b/src/components/pages/home/latest-l1-l2-transactions.tsx
@@ -9,7 +9,7 @@ import {
   CardTitle,
   CardFooter,
 } from "@/components/ui/card";
-import { l1Chain } from "@/lib/chains";
+import { l1Chain,l2Chain } from "@/lib/chains";
 
 const LatestL1L2Transaction = ({
   transaction,
@@ -48,7 +48,7 @@ const LatestL1L2Transaction = ({
           L2 Tx#{" "}
           <Link
             className="max-w-28 truncate text-primary hover:brightness-150 md:max-w-48 xl:max-w-28"
-            href={`/tx/${transaction.l2Hash}`}
+            href={`${l2Chain.blockExplorers.default.url}/tx/${transaction.l2Hash}`}
           >
             {transaction.l2Hash}
           </Link>

--- a/src/components/pages/tx/erc20.tsx
+++ b/src/components/pages/tx/erc20.tsx
@@ -1,61 +1,71 @@
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { TokenTransfer} from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { TokenTransfer } from "@/lib/utils";
 import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 
-
 const ERC20 = ({ tokenTransfers }: { tokenTransfers: TokenTransfer[] }) => {
-	return (
-		<ul className="list-inside max-h-64 overflow-y-auto pr-2" >
-			{tokenTransfers.map((transfer, index) => (
-				<li key={index} className="flex items-center gap-1">
-					<ChevronRight className="mr-1 size-4" />
-					<TooltipProvider>
-					<span>
-						<span className="font-semibold">From: </span> 
-						<Tooltip delayDuration={0}>
-							<TooltipTrigger>
-								<Link href={`/token/${transfer.from}`} className="text-primary hover:underline">{`${transfer.from.slice(0, 10)}...${transfer.from.slice(-9)}`}
-								</Link>
-							</TooltipTrigger>
-							<TooltipContent>
-								{transfer.from}
-							</TooltipContent>
-						</Tooltip>
-					</span>
-					<span>
-						<span className="font-semibold">To: </span> 
-						<Tooltip delayDuration={0}>
-							<TooltipTrigger>
-							<Link href={`/token/${transfer.to}`} className="text-primary hover:underline">{`${transfer.to.slice(0, 10)}...${transfer.to.slice(-9)}`}
-							</Link>
-							</TooltipTrigger>
-							<TooltipContent>
-								{transfer.to}
-							</TooltipContent>
-						</Tooltip>
-					</span>
-					<span>
-						<span className="font-semibold">For: </span> 
-						{transfer.amount}
-					</span>
-					<span>
-						<span className="font-semibold">Token: </span> 
-						<Tooltip delayDuration={0}>
-							<TooltipTrigger>
-								<Link href={`/token/${transfer.tokenAddress}`} className="text-primary hover:underline">{`${transfer.tokenAddress.slice(0, 10)}...${transfer.tokenAddress.slice(-9)}`}
-								</Link>
-							</TooltipTrigger>
-							<TooltipContent>
-								{transfer.tokenAddress}
-							</TooltipContent>
-						</Tooltip>
-					</span>
-					</TooltipProvider>
-				</li>
-			))}
-		</ul>
-	);
+  return (
+    <ul className="max-h-64 list-inside overflow-y-auto pr-2">
+      {tokenTransfers.map((transfer, index) => (
+        <li key={index} className="flex items-center gap-1">
+          <ChevronRight className="mr-1 size-4" />
+          <TooltipProvider>
+            <span>
+              <span className="font-semibold">From: </span>
+              <Tooltip delayDuration={0}>
+                <TooltipTrigger>
+                  <Link
+                    href={`/token/${transfer.from}`}
+                    className="text-primary hover:underline"
+                  >
+                    {`${transfer.from.slice(0, 10)}...${transfer.from.slice(-9)}`}
+                  </Link>
+                </TooltipTrigger>
+                <TooltipContent>{transfer.from}</TooltipContent>
+              </Tooltip>
+            </span>
+            <span>
+              <span className="font-semibold">To: </span>
+              <Tooltip delayDuration={0}>
+                <TooltipTrigger>
+                  <Link
+                    href={`/token/${transfer.to}`}
+                    className="text-primary hover:underline"
+                  >
+                    {`${transfer.to.slice(0, 10)}...${transfer.to.slice(-9)}`}
+                  </Link>
+                </TooltipTrigger>
+                <TooltipContent>{transfer.to}</TooltipContent>
+              </Tooltip>
+            </span>
+            <span>
+              <span className="font-semibold">For: </span>
+              {transfer.amount}
+            </span>
+            <span>
+              <span className="font-semibold">Token: </span>
+              <Tooltip delayDuration={0}>
+                <TooltipTrigger>
+                  <Link
+                    href={`/token/${transfer.tokenAddress}`}
+                    className="text-primary hover:underline"
+                  >
+                    {`${transfer.tokenAddress.slice(0, 10)}...${transfer.tokenAddress.slice(-9)}`}
+                  </Link>
+                </TooltipTrigger>
+                <TooltipContent>{transfer.tokenAddress}</TooltipContent>
+              </Tooltip>
+            </span>
+          </TooltipProvider>
+        </li>
+      ))}
+    </ul>
+  );
 };
 
 export default ERC20;

--- a/src/components/pages/tx/index.tsx
+++ b/src/components/pages/tx/index.tsx
@@ -4,7 +4,10 @@ import TransactionDetails from "@/components/pages/tx/transaction-details";
 import { parseTokenTransfers } from "@/lib/utils";
 
 const Tx = async ({ hash }: { hash: Hash }) => {
-  const [transaction, receipt] = await Promise.all([ l2PublicClient.getTransaction({ hash }), l2PublicClient.getTransactionReceipt({ hash })]);
+  const [transaction, receipt] = await Promise.all([
+    l2PublicClient.getTransaction({ hash }),
+    l2PublicClient.getTransactionReceipt({ hash }),
+  ]);
   const tokenTransfers = await parseTokenTransfers(receipt.logs);
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 md:gap-4 md:p-4">
@@ -21,7 +24,7 @@ const Tx = async ({ hash }: { hash: Hash }) => {
           gasPrice: transaction.gasPrice,
           timestamp: BigInt(0),
         }}
-        tokenTransfers = {tokenTransfers}
+        tokenTransfers={tokenTransfers}
       />
     </main>
   );

--- a/src/components/pages/tx/transaction-details.tsx
+++ b/src/components/pages/tx/transaction-details.tsx
@@ -1,15 +1,21 @@
 import Link from "next/link";
-import { Clock} from "lucide-react";
-import { TokenTransfer, formatTimestamp} from "@/lib/utils";
+import { Clock } from "lucide-react";
+import { TokenTransfer, formatTimestamp } from "@/lib/utils";
 import DescriptionListItem from "@/components/lib/description-list-item";
 import EthereumIcon from "@/components/lib/ethereum-icon";
 import { Card, CardContent } from "@/components/ui/card";
 import { Transaction } from "@/lib/types";
-import { formatGwei, formatEther} from "viem";
+import { formatGwei, formatEther } from "viem";
 import ERC20 from "./erc20";
 
-const TransactionDetails = ({ transaction, tokenTransfers}: { transaction: Transaction, tokenTransfers: TokenTransfer[] }) => {
-  return  (
+const TransactionDetails = ({
+  transaction,
+  tokenTransfers,
+}: {
+  transaction: Transaction;
+  tokenTransfers: TokenTransfer[];
+}) => {
+  return (
     <Card>
       <CardContent className="p-4">
         <dl>
@@ -38,16 +44,14 @@ const TransactionDetails = ({ transaction, tokenTransfers}: { transaction: Trans
               ({formatEther(transaction.gasPrice ?? BigInt(0))} ETH)
             </span>
           </DescriptionListItem>
-          {tokenTransfers.length > 0 && 
-          <DescriptionListItem title="ERC-20 Tokens Transferred">
-            <ERC20 tokenTransfers={tokenTransfers} />
-          </DescriptionListItem>
-          }
-
+          {tokenTransfers.length > 0 && (
+            <DescriptionListItem title="ERC-20 Tokens Transferred">
+              <ERC20 tokenTransfers={tokenTransfers} />
+            </DescriptionListItem>
+          )}
         </dl>
       </CardContent>
     </Card>
   );
-  
-}
+};
 export default TransactionDetails;

--- a/src/lib/contracts/erc-20/abi.ts
+++ b/src/lib/contracts/erc-20/abi.ts
@@ -1,224 +1,224 @@
 const abi = [
-	{
-			"constant": true,
-			"inputs": [],
-			"name": "name",
-			"outputs": [
-					{
-							"name": "",
-							"type": "string"
-					}
-			],
-			"payable": false,
-			"stateMutability": "view",
-			"type": "function"
-	},
-	{
-			"constant": false,
-			"inputs": [
-					{
-							"name": "_spender",
-							"type": "address"
-					},
-					{
-							"name": "_value",
-							"type": "uint256"
-					}
-			],
-			"name": "approve",
-			"outputs": [
-					{
-							"name": "",
-							"type": "bool"
-					}
-			],
-			"payable": false,
-			"stateMutability": "nonpayable",
-			"type": "function"
-	},
-	{
-			"constant": true,
-			"inputs": [],
-			"name": "totalSupply",
-			"outputs": [
-					{
-							"name": "",
-							"type": "uint256"
-					}
-			],
-			"payable": false,
-			"stateMutability": "view",
-			"type": "function"
-	},
-	{
-			"constant": false,
-			"inputs": [
-					{
-							"name": "_from",
-							"type": "address"
-					},
-					{
-							"name": "_to",
-							"type": "address"
-					},
-					{
-							"name": "_value",
-							"type": "uint256"
-					}
-			],
-			"name": "transferFrom",
-			"outputs": [
-					{
-							"name": "",
-							"type": "bool"
-					}
-			],
-			"payable": false,
-			"stateMutability": "nonpayable",
-			"type": "function"
-	},
-	{
-			"constant": true,
-			"inputs": [],
-			"name": "decimals",
-			"outputs": [
-					{
-							"name": "",
-							"type": "uint8"
-					}
-			],
-			"payable": false,
-			"stateMutability": "view",
-			"type": "function"
-	},
-	{
-			"constant": true,
-			"inputs": [
-					{
-							"name": "_owner",
-							"type": "address"
-					}
-			],
-			"name": "balanceOf",
-			"outputs": [
-					{
-							"name": "balance",
-							"type": "uint256"
-					}
-			],
-			"payable": false,
-			"stateMutability": "view",
-			"type": "function"
-	},
-	{
-			"constant": true,
-			"inputs": [],
-			"name": "symbol",
-			"outputs": [
-					{
-							"name": "",
-							"type": "string"
-					}
-			],
-			"payable": false,
-			"stateMutability": "view",
-			"type": "function"
-	},
-	{
-			"constant": false,
-			"inputs": [
-					{
-							"name": "_to",
-							"type": "address"
-					},
-					{
-							"name": "_value",
-							"type": "uint256"
-					}
-			],
-			"name": "transfer",
-			"outputs": [
-					{
-							"name": "",
-							"type": "bool"
-					}
-			],
-			"payable": false,
-			"stateMutability": "nonpayable",
-			"type": "function"
-	},
-	{
-			"constant": true,
-			"inputs": [
-					{
-							"name": "_owner",
-							"type": "address"
-					},
-					{
-							"name": "_spender",
-							"type": "address"
-					}
-			],
-			"name": "allowance",
-			"outputs": [
-					{
-							"name": "",
-							"type": "uint256"
-					}
-			],
-			"payable": false,
-			"stateMutability": "view",
-			"type": "function"
-	},
-	{
-			"payable": true,
-			"stateMutability": "payable",
-			"type": "fallback"
-	},
-	{
-			"anonymous": false,
-			"inputs": [
-					{
-							"indexed": true,
-							"name": "owner",
-							"type": "address"
-					},
-					{
-							"indexed": true,
-							"name": "spender",
-							"type": "address"
-					},
-					{
-							"indexed": false,
-							"name": "value",
-							"type": "uint256"
-					}
-			],
-			"name": "Approval",
-			"type": "event"
-	},
-	{
-			"anonymous": false,
-			"inputs": [
-					{
-							"indexed": true,
-							"name": "from",
-							"type": "address"
-					},
-					{
-							"indexed": true,
-							"name": "to",
-							"type": "address"
-					},
-					{
-							"indexed": false,
-							"name": "value",
-							"type": "uint256"
-					}
-			],
-			"name": "Transfer",
-			"type": "event"
-	}
+  {
+    constant: true,
+    inputs: [],
+    name: "name",
+    outputs: [
+      {
+        name: "",
+        type: "string",
+      },
+    ],
+    payable: false,
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: "_spender",
+        type: "address",
+      },
+      {
+        name: "_value",
+        type: "uint256",
+      },
+    ],
+    name: "approve",
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+      },
+    ],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "totalSupply",
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+      },
+    ],
+    payable: false,
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: "_from",
+        type: "address",
+      },
+      {
+        name: "_to",
+        type: "address",
+      },
+      {
+        name: "_value",
+        type: "uint256",
+      },
+    ],
+    name: "transferFrom",
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+      },
+    ],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "decimals",
+    outputs: [
+      {
+        name: "",
+        type: "uint8",
+      },
+    ],
+    payable: false,
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: "_owner",
+        type: "address",
+      },
+    ],
+    name: "balanceOf",
+    outputs: [
+      {
+        name: "balance",
+        type: "uint256",
+      },
+    ],
+    payable: false,
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "symbol",
+    outputs: [
+      {
+        name: "",
+        type: "string",
+      },
+    ],
+    payable: false,
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: "_to",
+        type: "address",
+      },
+      {
+        name: "_value",
+        type: "uint256",
+      },
+    ],
+    name: "transfer",
+    outputs: [
+      {
+        name: "",
+        type: "bool",
+      },
+    ],
+    payable: false,
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: "_owner",
+        type: "address",
+      },
+      {
+        name: "_spender",
+        type: "address",
+      },
+    ],
+    name: "allowance",
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+      },
+    ],
+    payable: false,
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    payable: true,
+    stateMutability: "payable",
+    type: "fallback",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: "owner",
+        type: "address",
+      },
+      {
+        indexed: true,
+        name: "spender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        name: "value",
+        type: "uint256",
+      },
+    ],
+    name: "Approval",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: "from",
+        type: "address",
+      },
+      {
+        indexed: true,
+        name: "to",
+        type: "address",
+      },
+      {
+        indexed: false,
+        name: "value",
+        type: "uint256",
+      },
+    ],
+    name: "Transfer",
+    type: "event",
+  },
 ] as const;
 
 export default abi;

--- a/src/lib/contracts/erc-20/contract.ts
+++ b/src/lib/contracts/erc-20/contract.ts
@@ -1,6 +1,5 @@
-
-import { getContract, Address } from 'viem'
-import { l2PublicClient } from '@/lib/chains'
+import { getContract, Address } from "viem";
+import { l2PublicClient } from "@/lib/chains";
 import abi from "@/lib/contracts/erc-20/abi";
 
 export const getERC20Contract = (address: Address) => {
@@ -8,5 +7,5 @@ export const getERC20Contract = (address: Address) => {
     address,
     abi,
     client: l2PublicClient,
-  })
-}
+  });
+};

--- a/src/lib/fetch-data.ts
+++ b/src/lib/fetch-data.ts
@@ -8,7 +8,7 @@ import { BlockWithTransactions, L1L2Transaction } from "@/lib/types";
 import { l2PublicClient } from "@/lib/chains";
 import l2OutputOracle from "@/lib/contracts/l2-output-oracle/contract";
 import { prisma } from "@/lib/prisma";
-import { fetchL1L2LatestTransactions } from "@/lib/utils"
+import { fetchL1L2LatestTransactions } from "@/lib/utils";
 
 const fetchL2LatestBlocks = async (): Promise<BlockWithTransactions[]> => {
   const latestBlock = await l2PublicClient.getBlock({

--- a/src/lib/fetch-data.ts
+++ b/src/lib/fetch-data.ts
@@ -8,6 +8,7 @@ import { BlockWithTransactions, L1L2Transaction } from "@/lib/types";
 import { l2PublicClient } from "@/lib/chains";
 import l2OutputOracle from "@/lib/contracts/l2-output-oracle/contract";
 import { prisma } from "@/lib/prisma";
+import { fetchL1L2LatestTransactions } from "@/lib/utils"
 
 const fetchL2LatestBlocks = async (): Promise<BlockWithTransactions[]> => {
   const latestBlock = await l2PublicClient.getBlock({
@@ -82,14 +83,15 @@ const fetchTokensPrices = async () => {
   };
 };
 
-const fetchLatestL1L2Transactions = async (): Promise<L1L2Transaction[]> =>
-  Array.from({ length: 10 }, (_, i) => i).map((i) => ({
-    l1BlockNumber: BigInt(20105119 - i),
-    l1Hash:
-      "0xc9f6566bfc6ff30a4d97dde51d011c47259268c8b7051f5ef0d23f407aece9a4",
-    l2Hash:
-      "0x8d721b30143b799d4b207bbea88cbf187862654357e7ddc318d6616f409045ae",
-  }));
+const fetchLatestL1L2Transactions = async (): Promise<L1L2Transaction[]> => {
+  try {
+    const transactions = await fetchL1L2LatestTransactions();
+    return transactions.slice(-10);
+  } catch (error) {
+    console.error("Error fetching latest L1L2 transactions:", error);
+    throw error;
+  }
+};
 
 export const fetchHomePageData = async () => {
   const [

--- a/src/lib/fetch-data.ts
+++ b/src/lib/fetch-data.ts
@@ -128,7 +128,7 @@ const fetchTokensPrices = async () => {
 const fetchLatestL1L2Transactions = async (): Promise<L1L2Transaction[]> => {
   try {
     const transactions = await fetchL1L2LatestTransactions();
-    return transactions.slice(-10);
+    return transactions.slice(0, 10);
   } catch (error) {
     console.error("Error fetching latest L1L2 transactions:", error);
     throw error;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,7 +13,7 @@ export type MessageArgs = {
   value: bigint;
   messageNonce: bigint;
   gasLimit: bigint;
-}
+};
 
 export type Transaction = {
   hash: Hash;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,15 @@ import {
 
 export type Block = { number: bigint; hash: Hash; timestamp: bigint };
 
+export type MessageArgs = {
+  target: Hash;
+  sender: Hash;
+  message: Hash;
+  value: bigint;
+  messageNonce: bigint;
+  gasLimit: bigint;
+}
+
 export type Transaction = {
   hash: Hash;
   blockNumber: bigint;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,7 +11,6 @@ import {
   Hash,
 } from "viem";
 import {
-  BlockWithTransactions,
   L1L2Transaction,
   MessageArgs,
 } from "@/lib/types";
@@ -176,81 +175,6 @@ export const fetchL1L2LatestTransactions = async (): Promise<
     console.error("Error fetching or matching logs:", error);
     throw error;
   }
-};
-
-export const fetchL2LatestBlocks = async (): Promise<
-  BlockWithTransactions[]
-> => {
-  const latestBlock = await l2PublicClient.getBlock({
-    includeTransactions: true,
-  });
-  const latestBlocks = await Promise.all(
-    [1, 2, 3, 4, 5].map((index) =>
-      l2PublicClient.getBlock({
-        blockNumber: latestBlock.number - BigInt(index),
-        includeTransactions: true,
-      }),
-    ),
-  );
-  const blocks = [latestBlock, ...latestBlocks];
-  return blocks.map(({ number, hash, timestamp, transactions }) => ({
-    number,
-    hash,
-    timestamp,
-    transactions: transactions.map(
-      ({ hash, blockNumber, from, to, value }) => ({
-        hash,
-        blockNumber,
-        from,
-        to,
-        value,
-        timestamp,
-      }),
-    ),
-  }));
-};
-
-export const fetchTokensPrices = async () => {
-  const date = formatISO(subDays(new Date(), 1), {
-    representation: "date",
-  });
-  const [
-    ethResponseToday,
-    ethResponseYesterday,
-    opResponseToday,
-    opResponseYesterday,
-  ] = await Promise.all([
-    fetch("https://api.coinbase.com/v2/prices/ETH-USD/spot"),
-    fetch(`https://api.coinbase.com/v2/prices/ETH-USD/spot?date=${date}`),
-    fetch("https://api.coinbase.com/v2/prices/OP-USD/spot"),
-    fetch(`https://api.coinbase.com/v2/prices/OP-USD/spot?date=${date}`),
-  ]);
-  const [ethJsonToday, ethJsonYesterday, opJsonToday, opJsonYesterday] =
-    await Promise.all([
-      ethResponseToday.json(),
-      ethResponseYesterday.json(),
-      opResponseToday.json(),
-      opResponseYesterday.json(),
-    ]);
-  type GetSpotPriceResponse = {
-    data: { amount: string; base: string; currency: string };
-  };
-  const {
-    data: { amount: ethPriceToday },
-  } = ethJsonToday as GetSpotPriceResponse;
-  const {
-    data: { amount: ethPriceYesterday },
-  } = ethJsonYesterday as GetSpotPriceResponse;
-  const {
-    data: { amount: opPriceToday },
-  } = opJsonToday as GetSpotPriceResponse;
-  const {
-    data: { amount: opPriceYesterday },
-  } = opJsonYesterday as GetSpotPriceResponse;
-  return {
-    eth: { today: Number(ethPriceToday), yesterday: Number(ethPriceYesterday) },
-    op: { today: Number(opPriceToday), yesterday: Number(opPriceYesterday) },
-  };
 };
 
 export const formatEther = (ether: bigint, precision = 5) =>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -24,7 +24,7 @@ function encodeL1Args(args: MessageArgs): Hash {
   return encodedMessage;
 }
 
-async function searchHashInLogs(hash: Hash): Promise<any | null> {
+async function searchHashInLogs(hash: Hash): Promise<any> {
   try {
     const logs = await fetchL2RelayedMessageLatestLogs();
 
@@ -44,7 +44,7 @@ async function calculateHash(args: MessageArgs): Promise<Hash> {
   return calculatedHash;
 };
 
-export const searchHashMsg = async (): Promise<L1L2Transaction[]> => {
+export const fetchL1L2LatestTransactions = async (): Promise<L1L2Transaction[]> => {
   try {
     const sentMessageLogs = await fetchL1SentMessageLatestLogs();
     const l1l2LatestTransacions: any[] = [];

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -24,7 +24,7 @@ function encodeL1Args(args: MessageArgs): Hash {
   return encodedMessage;
 }
 
-export const searchHashInLogs = async (hash: string): Promise<any | null> => {
+async function searchHashInLogs(hash: Hash): Promise<any | null> {
   try {
     const logs = await fetchL2RelayedMessageLatestLogs();
 
@@ -37,7 +37,7 @@ export const searchHashInLogs = async (hash: string): Promise<any | null> => {
   }
 };
 
-export const calculateHash = async (args: MessageArgs): Promise<string> => {
+async function calculateHash(args: MessageArgs): Promise<Hash> {
   const encodedMessage = encodeL1Args(args);
   const calculatedHash = keccak256(encodedMessage);
 
@@ -79,9 +79,7 @@ export const searchHashMsg = async (): Promise<L1L2Transaction[]> => {
   }
 };
 
-export const messageExtension1ArgsByHash = async (
-  transactionHash: string,
-): Promise<any> => {
+async function messageExtension1ArgsByHash(transactionHash: Hash): Promise<any> {
   try {
     const sentMessageExtension1Logs =
       await fetchL1SentMessageExtension1LatestLogs();
@@ -102,7 +100,7 @@ export const messageExtension1ArgsByHash = async (
   }
 };
 
-export const fetchL2RelayedMessageLatestLogs = async (): Promise<any[]> => {
+async function fetchL2RelayedMessageLatestLogs(): Promise<any[]> {
   try {
     const latestBlock = await l2PublicClient.getBlockNumber();
 
@@ -120,9 +118,7 @@ export const fetchL2RelayedMessageLatestLogs = async (): Promise<any[]> => {
   }
 };
 
-export const fetchL1SentMessageExtension1LatestLogs = async (): Promise<
-  any[]
-> => {
+async function fetchL1SentMessageExtension1LatestLogs(): Promise<any[]> {
   try {
     const latestBlock = await l1PublicClient.getBlockNumber();
 
@@ -142,7 +138,7 @@ export const fetchL1SentMessageExtension1LatestLogs = async (): Promise<
   }
 };
 
-export const fetchL1SentMessageLatestLogs = async (): Promise<any[]> => {
+async function fetchL1SentMessageLatestLogs(): Promise<any[]> {
   try {
     const latestBlock = await l1PublicClient.getBlockNumber();
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,7 +12,7 @@ import abi from "./contracts/l2-cross-domain-messenger/abi";
 
 export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
-interface MessageArgs {
+type MessageArgs = {
   target: `0x${string}`;
   sender: `0x${string}`;
   message: `0x${string}`;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,15 +13,20 @@ import l2CrossDomainMessengerAbi from "./contracts/l2-cross-domain-messenger/abi
 export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
 function encodeL1Args(args: MessageArgs): Hash {
-  const { target, sender, message, value, messageNonce, gasLimit } = args;
+  try {
+    const { target, sender, message, value, messageNonce, gasLimit } = args;
 
-  const encodedMessage = encodeFunctionData({
-    abi: l2CrossDomainMessengerAbi,
-    functionName: "relayMessage",
-    args: [messageNonce, sender, target, value, gasLimit, message],
-  });
+    const encodedMessage = encodeFunctionData({
+      abi: l2CrossDomainMessengerAbi,
+      functionName: "relayMessage",
+      args: [messageNonce, sender, target, value, gasLimit, message],
+    });
 
-  return encodedMessage;
+    return encodedMessage;
+  } catch (error) {
+  console.error("Error encoding L1 arguments", error);
+    throw error;
+  }
 }
 
 async function searchHashInLogs(hash: Hash): Promise<any> {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,6 +9,7 @@ import {
   encodeFunctionData,
   keccak256,
   Hash,
+  getBlock
 } from "viem";
 import { MessageArgs } from "@/lib/types";
 import { l1PublicClient, l2PublicClient } from "@/lib/chains";
@@ -39,13 +40,13 @@ function encodeL1Args(args: MessageArgs): Hash {
 
 async function fetchL2RelayedMessageLatestLogs(): Promise<any[]> {
   try {
-    const latestBlock = await l2PublicClient.getBlockNumber();
-
-    const startBlock = latestBlock - BigInt(10000);
+    const latestBlock = await l2PublicClient.getBlock({ blockTag: 'latest' });
+    console.log(latestBlock.number);
+    const startBlock = latestBlock.number - BigInt(10000);
 
     const logs = l2CrossDomainMessenger.getEvents.RelayedMessage(undefined, {
       fromBlock: startBlock,
-      toBlock: latestBlock,
+      toBlock: latestBlock.number,
     });
 
     return logs;
@@ -57,15 +58,15 @@ async function fetchL2RelayedMessageLatestLogs(): Promise<any[]> {
 
 async function fetchL1SentMessageExtension1LatestLogs(): Promise<any[]> {
   try {
-    const latestBlock = await l1PublicClient.getBlockNumber();
+    const latestBlock = await l1PublicClient.getBlock({ blockTag: 'latest' });
 
-    const startBlock = latestBlock - BigInt(1000);
+    const startBlock = latestBlock.number - BigInt(1000);
 
     const logs = await l1CrossDomainMessenger.getEvents.SentMessageExtension1(
       undefined,
       {
         fromBlock: startBlock,
-        toBlock: latestBlock,
+        toBlock: latestBlock.number,
       },
     );
     return logs;
@@ -120,14 +121,17 @@ export const messageExtension1ArgsByHash = async(
 
 export const fetchL1SentMessageLatestLogs = async (): Promise<any[]> => {
   try {
-    const latestBlock = await l1PublicClient.getBlockNumber();
+    const latestBlock = await l1PublicClient.getBlock({ blockTag: 'latest' });
 
-    const startBlock = latestBlock - BigInt(1000);
+    const startBlock = latestBlock.number - BigInt(1000);
 
-    const logs = await l1CrossDomainMessenger.getEvents.SentMessage(undefined, {
-      fromBlock: startBlock,
-      toBlock: latestBlock,
-    });
+    const logs = await l1CrossDomainMessenger.getEvents.SentMessage(
+      undefined,
+      {
+        fromBlock: startBlock,
+        toBlock: latestBlock.number,
+      },
+    );
     return logs;
   } catch (error) {
     console.error("Error fetching logs:", error);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,11 +2,97 @@ import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { subDays, formatISO, fromUnixTime, formatDistance } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
-import { formatEther as viemFormatEther } from "viem";
+import {
+  formatEther as viemFormatEther,
+  decodeEventLog,
+  parseAbiItem,
+} from "viem";
 import { BlockWithTransactions, L1L2Transaction } from "@/lib/types";
-import { l2PublicClient } from "@/lib/chains";
+import { l1PublicClient, l2PublicClient } from "@/lib/chains";
+import abiL1CrossDomainMessenger from "@/lib/contracts/l1-cross-domain-messenger/abi";
+import abiL2CrossDomainMessenger from "@/lib/contracts/l2-cross-domain-messenger/abi";
+import l1CrossDomainMessenger from "./contracts/l1-cross-domain-messenger/contract";
+import l2CrossDomainMessenger from "./contracts/l2-cross-domain-messenger/contract";
 
 export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+
+export const fetchL2LatestLogs = async (): Promise<any[]> => {
+  try {
+    const latestBlock = await l2PublicClient.getBlockNumber();
+
+    const startBlock = latestBlock - BigInt(1000);
+    const endBlock = latestBlock;
+
+    const logs = await l2PublicClient.getLogs({
+      fromBlock: startBlock,
+      toBlock: endBlock,
+      address: l2CrossDomainMessenger.address,
+      event: parseAbiItem("event RelayedMessage(bytes32 msgHash)"),
+    });
+
+    const decodedLogs = logs.map((log) =>
+      decodeEventLog({
+        abi: abiL2CrossDomainMessenger,
+        data: log.data,
+        topics: log.topics,
+      }),
+    );
+
+    return decodedLogs;
+  } catch (error) {
+    console.error("Error fetching logs:", error);
+    throw error;
+  }
+};
+
+export const fetchL1LatestLogs = async (): Promise<any[]> => {
+  try {
+    const latestBlock = await l1PublicClient.getBlockNumber();
+
+    const startBlock = latestBlock - BigInt(1000);
+    const endBlock = latestBlock;
+
+    const SentMessageLogs = await l1PublicClient.getLogs({
+      fromBlock: startBlock,
+      toBlock: endBlock,
+      address: l1CrossDomainMessenger.address,
+      event: parseAbiItem(
+        "event SentMessage(address indexed target, address indexed sender, bytes message, uint256 messageNonce, uint256 minGasLimit)",
+      ),
+    });
+
+    const sentMessageExtension1Logs = await l1PublicClient.getLogs({
+      fromBlock: startBlock,
+      toBlock: endBlock,
+      address: l1CrossDomainMessenger.address,
+      event: parseAbiItem(
+        "event SentMessageExtension1(address indexed sender, uint256 value)",
+      ),
+    });
+
+    const decodedSentMessageLogs = SentMessageLogs.map((log) =>
+      decodeEventLog({
+        abi: abiL1CrossDomainMessenger,
+        data: log.data,
+        topics: log.topics,
+      }),
+    );
+
+    const decodedSentMessageExtension1Logs = sentMessageExtension1Logs.map(
+      (log) =>
+        decodeEventLog({
+          abi: abiL1CrossDomainMessenger,
+          data: log.data,
+          topics: log.topics,
+        }),
+    );
+
+    return [...decodedSentMessageLogs, ...decodedSentMessageExtension1Logs];
+  } catch (error) {
+    console.error("Error fetching logs:", error);
+    throw error;
+  }
+};
 
 export const fetchL2LatestBlocks = async (): Promise<
   BlockWithTransactions[]

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,7 +3,7 @@ import { twMerge } from "tailwind-merge";
 import { fromUnixTime, formatDistance } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
 import { formatEther as viemFormatEther, Log, formatUnits, encodeFunctionData, keccak256 } from "viem";
-import { BlockWithTransactions, L1L2Transaction } from "@/lib/types";
+import { BlockWithTransactions, L1L2Transaction, MessageArgs} from "@/lib/types";
 import { l1PublicClient, l2PublicClient } from "@/lib/chains";
 import { getERC20Contract } from "./contracts/erc-20/contract";
 import l1CrossDomainMessenger from "./contracts/l1-cross-domain-messenger/contract";
@@ -11,15 +11,6 @@ import l2CrossDomainMessenger from "./contracts/l2-cross-domain-messenger/contra
 import abi from "./contracts/l2-cross-domain-messenger/abi";
 
 export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
-
-type MessageArgs = {
-  target: `0x${string}`;
-  sender: `0x${string}`;
-  message: `0x${string}`;
-  value: bigint;
-  messageNonce: bigint;
-  gasLimit: bigint;
-}
 
 function encodeL1Args(args: MessageArgs): `0x${string}` {
   const { target, sender, message, value, messageNonce, gasLimit } = args;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -44,41 +44,6 @@ async function calculateHash(args: MessageArgs): Promise<Hash> {
   return calculatedHash;
 };
 
-export const fetchL1L2LatestTransactions = async (): Promise<L1L2Transaction[]> => {
-  try {
-    const sentMessageLogs = await fetchL1SentMessageLatestLogs();
-    const l1l2LatestTransacions: any[] = [];
-
-    for (const log of sentMessageLogs) {
-      let messageValue = await messageExtension1ArgsByHash(log.transactionHash);
-      let args: MessageArgs = {
-        target: log.args.target,
-        sender: log.args.sender,
-        message: log.args.message,
-        messageNonce: log.args.messageNonce,
-        value: messageValue,
-        gasLimit: log.args.gasLimit,
-      };
-      let calculatedHash = await calculateHash(args);
-      let l2Message = await searchHashInLogs(calculatedHash);
-
-      if (l2Message) {
-        let transaction: L1L2Transaction = {
-          l1BlockNumber: log.blockNumber,
-          l1Hash: log.transactionHash, 
-          l2Hash: l2Message.transactionHash  
-        };
-        l1l2LatestTransacions.push(transaction);
-      }
-
-    }
-    return l1l2LatestTransacions;
-  } catch (error) {
-    console.error("Error fetching or matching logs:", error);
-    throw error;
-  }
-};
-
 async function messageExtension1ArgsByHash(transactionHash: Hash): Promise<any> {
   try {
     const sentMessageExtension1Logs =
@@ -151,6 +116,41 @@ async function fetchL1SentMessageLatestLogs(): Promise<any[]> {
     return logs;
   } catch (error) {
     console.error("Error fetching logs:", error);
+    throw error;
+  }
+};
+
+export const fetchL1L2LatestTransactions = async (): Promise<L1L2Transaction[]> => {
+  try {
+    const sentMessageLogs = await fetchL1SentMessageLatestLogs();
+    const l1l2LatestTransacions: any[] = [];
+
+    for (const log of sentMessageLogs) {
+      let messageValue = await messageExtension1ArgsByHash(log.transactionHash);
+      let args: MessageArgs = {
+        target: log.args.target,
+        sender: log.args.sender,
+        message: log.args.message,
+        messageNonce: log.args.messageNonce,
+        value: messageValue,
+        gasLimit: log.args.gasLimit,
+      };
+      let calculatedHash = await calculateHash(args);
+      let l2Message = await searchHashInLogs(calculatedHash);
+
+      if (l2Message) {
+        let transaction: L1L2Transaction = {
+          l1BlockNumber: log.blockNumber,
+          l1Hash: log.transactionHash, 
+          l2Hash: l2Message.transactionHash  
+        };
+        l1l2LatestTransacions.push(transaction);
+      }
+
+    }
+    return l1l2LatestTransacions;
+  } catch (error) {
+    console.error("Error fetching or matching logs:", error);
     throw error;
   }
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -74,7 +74,7 @@ async function fetchL2RelayedMessageLatestLogs(): Promise<any[]> {
   try {
     const latestBlock = await l2PublicClient.getBlockNumber();
 
-    const startBlock = latestBlock - BigInt(1000);
+    const startBlock = latestBlock - BigInt(10000);
 
     const logs = l2CrossDomainMessenger.getEvents.RelayedMessage(undefined, {
       fromBlock: startBlock,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -253,15 +253,6 @@ export const fetchTokensPrices = async () => {
   };
 };
 
-export const fetchLatestL1L2Transactions = async (): Promise<
-  L1L2Transaction[]
-> =>
-  Array.from({ length: 6 }, (_, i) => i).map((i) => ({
-    l1BlockNumber: BigInt(20105119 - i),
-    l1Hash: "0xte",
-    l2Hash: "0xteteo",
-  }));
-
 export const formatEther = (ether: bigint, precision = 5) =>
   new Intl.NumberFormat("en-US", {
     style: "decimal",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -36,6 +36,45 @@ function encodeL1Args(args: MessageArgs): Hash {
   }
 }
 
+
+async function fetchL2RelayedMessageLatestLogs(): Promise<any[]> {
+  try {
+    const latestBlock = await l2PublicClient.getBlockNumber();
+
+    const startBlock = latestBlock - BigInt(10000);
+
+    const logs = l2CrossDomainMessenger.getEvents.RelayedMessage(undefined, {
+      fromBlock: startBlock,
+      toBlock: latestBlock,
+    });
+
+    return logs;
+  } catch (error) {
+    console.error("Error fetching logs:", error);
+    throw error;
+  }
+}
+
+async function fetchL1SentMessageExtension1LatestLogs(): Promise<any[]> {
+  try {
+    const latestBlock = await l1PublicClient.getBlockNumber();
+
+    const startBlock = latestBlock - BigInt(1000);
+
+    const logs = await l1CrossDomainMessenger.getEvents.SentMessageExtension1(
+      undefined,
+      {
+        fromBlock: startBlock,
+        toBlock: latestBlock,
+      },
+    );
+    return logs;
+  } catch (error) {
+    console.error("Error fetching logs:", error);
+    throw error;
+  }
+}
+
 export const searchHashInLogs = async(hash: Hash): Promise<any> => {
   try {
     const logs = await fetchL2RelayedMessageLatestLogs();
@@ -75,44 +114,6 @@ export const messageExtension1ArgsByHash = async(
     return matchedLog.args.value;
   } catch (error) {
     console.error("Error fetching or matching logs:", error);
-    throw error;
-  }
-}
-
-async function fetchL2RelayedMessageLatestLogs(): Promise<any[]> {
-  try {
-    const latestBlock = await l2PublicClient.getBlockNumber();
-
-    const startBlock = latestBlock - BigInt(10000);
-
-    const logs = l2CrossDomainMessenger.getEvents.RelayedMessage(undefined, {
-      fromBlock: startBlock,
-      toBlock: latestBlock,
-    });
-
-    return logs;
-  } catch (error) {
-    console.error("Error fetching logs:", error);
-    throw error;
-  }
-}
-
-async function fetchL1SentMessageExtension1LatestLogs(): Promise<any[]> {
-  try {
-    const latestBlock = await l1PublicClient.getBlockNumber();
-
-    const startBlock = latestBlock - BigInt(1000);
-
-    const logs = await l1CrossDomainMessenger.getEvents.SentMessageExtension1(
-      undefined,
-      {
-        fromBlock: startBlock,
-        toBlock: latestBlock,
-      },
-    );
-    return logs;
-  } catch (error) {
-    console.error("Error fetching logs:", error);
     throw error;
   }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,7 @@ import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { fromUnixTime, formatDistance } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
-import { formatEther as viemFormatEther, Log, formatUnits, encodeFunctionData, keccak256 } from "viem";
+import { formatEther as viemFormatEther, Log, formatUnits, encodeFunctionData, keccak256, Hash} from "viem";
 import { BlockWithTransactions, L1L2Transaction, MessageArgs} from "@/lib/types";
 import { l1PublicClient, l2PublicClient } from "@/lib/chains";
 import { getERC20Contract } from "./contracts/erc-20/contract";
@@ -12,7 +12,7 @@ import abi from "./contracts/l2-cross-domain-messenger/abi";
 
 export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
-function encodeL1Args(args: MessageArgs): `0x${string}` {
+function encodeL1Args(args: MessageArgs): Hash {
   const { target, sender, message, value, messageNonce, gasLimit } = args;
 
   const encodedMessage = encodeFunctionData({

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -153,6 +153,8 @@ export const fetchL1L2LatestTransactions = async (): Promise<L1L2Transaction[]> 
       }
 
     }
+    l1l2LatestTransacions.sort((a, b) => Number(b.l1BlockNumber) - Number(a.l1BlockNumber));
+
     return l1l2LatestTransacions;
   } catch (error) {
     console.error("Error fetching or matching logs:", error);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,7 +8,7 @@ import { l1PublicClient, l2PublicClient } from "@/lib/chains";
 import { getERC20Contract } from "./contracts/erc-20/contract";
 import l1CrossDomainMessenger from "./contracts/l1-cross-domain-messenger/contract";
 import l2CrossDomainMessenger from "./contracts/l2-cross-domain-messenger/contract";
-import abi from "./contracts/l2-cross-domain-messenger/abi";
+import l2CrossDomainMessengerAbi from "./contracts/l2-cross-domain-messenger/abi";
 
 export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
@@ -16,7 +16,7 @@ function encodeL1Args(args: MessageArgs): Hash {
   const { target, sender, message, value, messageNonce, gasLimit } = args;
 
   const encodedMessage = encodeFunctionData({
-    abi: abi,
+    abi: l2CrossDomainMessengerAbi,
     functionName: "relayMessage",
     args: [messageNonce, sender, target, value, gasLimit, message],
   });


### PR DESCRIPTION
## Background
- Solves issue #11 
## Summary
- Retrieve the latest L1->L2 transactions fetching `SentMessage`/`SentMessageExtension1` and `RelayedMessage` events log from `L1CrossDomainMessenger` and `L2CrossDomainMessenger` contracts in Ethereum and Optimism.
- Remove hardcoded data.
- Filter the last 10 transactions.
## Visual result
- 
![image](https://github.com/walnuthq/op-scan/assets/66186331/edcbd793-18b3-454f-96e3-7cbf2464b5f4)
