### PR TITLE
feat: partial solution for L1 -> L2 transactions table styling

### DIFF
--- a/src/app/txs-enqueued/page.tsx
+++ b/src/app/txs-enqueued/page.tsx
@@ -1,0 +1,17 @@
+import LatestL1L2TransactionsTable from "@/components/pages/txs/latest-l1-l2-transactions-table";
+import { fetchLatestL1L2Transactions } from "@/lib/utils";
+
+const TxsEnqueuedPage = async () => {
+  const transactions = await fetchLatestL1L2Transactions();
+
+  return (
+    <main className="flex flex-1 flex-col gap-4 p-4 md:gap-4 md:p-4">
+      <h2 className="mt-10 scroll-m-20 border-b pb-2 text-xl font-semibold tracking-tight transition-colors first:mt-0">
+        L1 - L2 Transactions
+      </h2>
+      <LatestL1L2TransactionsTable transactions={transactions} />
+    </main>
+  );
+};
+
+export default TxsEnqueuedPage;

--- a/src/components/pages/home/latest-l1-l2-transactions.tsx
+++ b/src/components/pages/home/latest-l1-l2-transactions.tsx
@@ -77,7 +77,7 @@ const LatestL1L2Transactions = ({
     </CardContent>
     <CardFooter className="flex justify-center border-t">
       <Link
-        href="/l1-l2-txs"
+        href="/txs-enqueued"
         className="pt-6 text-primary hover:brightness-150"
       >
         View all L1→L2 transactions →

--- a/src/components/pages/txs/latest-l1-l2-transactions-table.tsx
+++ b/src/components/pages/txs/latest-l1-l2-transactions-table.tsx
@@ -1,8 +1,8 @@
+// src/components/tx/latest-l1-l2-transactions-table.tsx
 import Link from "next/link";
 import { formatTimestamp } from "@/lib/utils";
 import { Card, CardContent } from "@/components/ui/card";
 import { L1L2Transaction } from "@/lib/types";
-import { SquareArrowOutUpRight } from "lucide-react";
 import {
   Table,
   TableCaption,
@@ -12,6 +12,7 @@ import {
   TableBody,
   TableCell,
 } from "@/components/ui/table";
+import { SquareArrowOutUpRight } from "lucide-react";
 import { l1Chain } from "@/lib/chains";
 
 const LatestL1L2TransactionsTable = ({
@@ -22,46 +23,76 @@ const LatestL1L2TransactionsTable = ({
   <Card>
     <CardContent className="p-4">
       <Table className="w-full table-auto">
-        <TableCaption>
+        <TableCaption className="text-lg font-semibold">
           List of latest L1 - L2 transactions
         </TableCaption>
         <TableHeader>
           <TableRow>
-            <TableHead className="max-w-[10rem]">Block No</TableHead>
-            <TableHead className="max-w-[10rem]">L2 Tx Hash</TableHead>
-            <TableHead className="max-w-[10rem]">Timestamp</TableHead>
-            <TableHead className="max-w-[10rem]">L1 Tx Hash</TableHead>
-            <TableHead className="max-w-[10rem]">L1 Tx Origin</TableHead>
-            <TableHead className="max-w-[8rem]">Gas Limit</TableHead>
+            <TableHead className="px-4 py-2">Block No</TableHead>
+            <TableHead className="px-4 py-2">L2 Tx Hash</TableHead>
+            <TableHead className="px-4 py-2">Timestamp</TableHead>
+            <TableHead className="px-4 py-2">L1 Tx Hash</TableHead>
+            <TableHead className="px-4 py-2">L1 Tx Origin</TableHead>
+            <TableHead className="px-4 py-2">Gas Limit</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {transactions.map((transaction) => (
             <TableRow key={transaction.l2Hash}>
-              <TableCell className="max-w-[10rem] truncate">
-                <Link href={`https://explorer.l1.com/block/${transaction.l1BlockNumber}`}>
-                  {transaction.l1BlockNumber.toString()}
-                </Link>
+              <TableCell className="px-4 py-2 max-w-[10rem] truncate">
+                <div className="flex items-center gap-1 text-sm">
+                  <a
+                    className="flex items-center truncate text-primary hover:brightness-150"
+                    href={`${l1Chain.blockExplorers.default.url}/block/${transaction.l1BlockNumber}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <span className="truncate">{transaction.l1BlockNumber.toString()}</span>
+                    <SquareArrowOutUpRight className="ml-1 w-4 h-4 flex-shrink-0" />
+                  </a>
+                </div>
               </TableCell>
-              <TableCell className="max-w-[10rem] truncate">
-                <Link href={`/txs/${transaction.l2Hash}`}>
-                  {transaction.l2Hash}
-                </Link>
+              <TableCell className="px-4 py-2 max-w-[14rem] truncate">
+                <div className="flex items-center gap-1 text-sm">
+                  <Link
+                    className="flex items-center truncate text-primary hover:brightness-150"
+                    href={`${l1Chain.blockExplorers.default.url}/tx/${transaction.l2Hash}`}
+                  >
+                    <span className="truncate">{transaction.l2Hash}</span>
+                    <SquareArrowOutUpRight className="ml-1 w-4 h-4 flex-shrink-0" />
+                  </Link>
+                </div>
               </TableCell>
-              <TableCell className="max-w-[10rem] truncate">
+              <TableCell className="px-4 py-2 max-w-[10rem] truncate">
                 {formatTimestamp(transaction.timestamp, false)}
               </TableCell>
-              <TableCell className="max-w-[10rem] truncate">
-                <Link href={`https://explorer.l1.com/tx/${transaction.l1TxHash}`}>
-                  {transaction.l1TxHash}
-                </Link>
+              <TableCell className="px-4 py-2 max-w-[14rem] truncate">
+                <div className="flex items-center gap-1 text-sm">
+                  <a
+                    className="flex items-center truncate text-primary hover:brightness-150"
+                    href={`${l1Chain.blockExplorers.default.url}/tx/${transaction.l1TxHash}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <span className="truncate">{transaction.l1TxHash}</span>
+                    <SquareArrowOutUpRight className="ml-1 w-4 h-4 flex-shrink-0" />
+                  </a>
+                </div>
               </TableCell>
-              <TableCell className="max-w-[10rem] truncate">
-                <Link href={`https://explorer.l1.com/address/${transaction.l1TxOrigin}`}>
-                  {transaction.l1TxOrigin}
-                </Link>
+              <TableCell className="px-4 py-2 max-w-[14rem] truncate">
+                <div className="flex items-center gap-1 text-sm">
+                  <a
+                    className="flex items-center truncate text-primary hover:brightness-150"
+                    href={`${l1Chain.blockExplorers.default.url}/address/${transaction.l1TxOrigin}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <span className="truncate">{transaction.l1TxOrigin}</span>
+                    <SquareArrowOutUpRight className="ml-1 w-4 h-4 flex-shrink-0" />
+                  </a>
+                </div>
               </TableCell>
-              <TableCell className="max-w-[8rem] truncate">
+              <TableCell className="px-4 py-2 max-w-[8rem] truncate">
                 {transaction.gasLimit}
               </TableCell>
             </TableRow>

--- a/src/components/pages/txs/latest-l1-l2-transactions-table.tsx
+++ b/src/components/pages/txs/latest-l1-l2-transactions-table.tsx
@@ -56,10 +56,9 @@ const LatestL1L2TransactionsTable = ({
                 <div className="flex items-center gap-1 text-sm">
                   <Link
                     className="flex items-center truncate text-primary hover:brightness-150"
-                    href={`${l1Chain.blockExplorers.default.url}/tx/${transaction.l2Hash}`}
+                    href={`/tx/${transaction.l2Hash}`}
                   >
                     <span className="truncate">{transaction.l2Hash}</span>
-                    <SquareArrowOutUpRight className="ml-1 w-4 h-4 flex-shrink-0" />
                   </Link>
                 </div>
               </TableCell>

--- a/src/components/pages/txs/latest-l1-l2-transactions-table.tsx
+++ b/src/components/pages/txs/latest-l1-l2-transactions-table.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { formatTimestamp } from "@/lib/utils";
+import { Card, CardContent } from "@/components/ui/card";
+import { L1L2Transaction } from "@/lib/types";
+import { SquareArrowOutUpRight } from "lucide-react";
+import {
+  Table,
+  TableCaption,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table";
+import { l1Chain } from "@/lib/chains";
+
+const LatestL1L2TransactionsTable = ({
+  transactions,
+}: {
+  transactions: L1L2Transaction[];
+}) => (
+  <Card>
+    <CardContent className="p-4">
+      <Table className="w-full table-auto">
+        <TableCaption>
+          List of latest L1 - L2 transactions
+        </TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="max-w-[10rem]">Block No</TableHead>
+            <TableHead className="max-w-[10rem]">L2 Tx Hash</TableHead>
+            <TableHead className="max-w-[10rem]">Timestamp</TableHead>
+            <TableHead className="max-w-[10rem]">L1 Tx Hash</TableHead>
+            <TableHead className="max-w-[10rem]">L1 Tx Origin</TableHead>
+            <TableHead className="max-w-[8rem]">Gas Limit</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {transactions.map((transaction) => (
+            <TableRow key={transaction.l2Hash}>
+              <TableCell className="max-w-[10rem] truncate">
+                <Link href={`https://explorer.l1.com/block/${transaction.l1BlockNumber}`}>
+                  {transaction.l1BlockNumber.toString()}
+                </Link>
+              </TableCell>
+              <TableCell className="max-w-[10rem] truncate">
+                <Link href={`/txs/${transaction.l2Hash}`}>
+                  {transaction.l2Hash}
+                </Link>
+              </TableCell>
+              <TableCell className="max-w-[10rem] truncate">
+                {formatTimestamp(transaction.timestamp, false)}
+              </TableCell>
+              <TableCell className="max-w-[10rem] truncate">
+                <Link href={`https://explorer.l1.com/tx/${transaction.l1TxHash}`}>
+                  {transaction.l1TxHash}
+                </Link>
+              </TableCell>
+              <TableCell className="max-w-[10rem] truncate">
+                <Link href={`https://explorer.l1.com/address/${transaction.l1TxOrigin}`}>
+                  {transaction.l1TxOrigin}
+                </Link>
+              </TableCell>
+              <TableCell className="max-w-[8rem] truncate">
+                {transaction.gasLimit}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </CardContent>
+  </Card>
+);
+
+export default LatestL1L2TransactionsTable;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,4 +18,8 @@ export type L1L2Transaction = {
   l1BlockNumber: bigint;
   l1Hash: Hash;
   l2Hash: Hash;
+  timestamp: bigint;
+  l1TxHash: string;
+  l1TxOrigin: string;
+  gasLimit: number;
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -86,12 +86,16 @@ export const fetchTokensPrices = async () => {
 export const fetchLatestL1L2Transactions = async (): Promise<
   L1L2Transaction[]
 > =>
-  Array.from({ length: 6 }, (_, i) => i).map((i) => ({
+  Array.from({ length: 50 }, (_, i) => i).map((i) => ({
     l1BlockNumber: BigInt(20105119 - i),
     l1Hash:
       "0xc9f6566bfc6ff30a4d97dde51d011c47259268c8b7051f5ef0d23f407aece9a4",
     l2Hash:
       "0x8d721b30143b799d4b207bbea88cbf187862654357e7ddc318d6616f409045ae",
+    timestamp: BigInt(Date.now()), // Timestamp example
+    l1TxHash: "0xc9f6566bfc6ff30a4d97dde51d011c47259268c8b7051f5ef0d23f407aece9a4",
+    l1TxOrigin: "0x8d721b30143b799d4b207bbea88cbf187862654357e7ddc318d6616f409045ae",
+    gasLimit: 200000,
   }));
 
 export const formatEther = (ether: bigint, precision = 5) =>


### PR DESCRIPTION
## Feature: Add L1 -> L2 Transactions Table Page

### Description
This PR introduces a new page for displaying the latest L1 to L2 transactions. The new page includes a table that shows the following details for each transaction:
- L1 Block Number
- L2 Transaction Hash
- Timestamp
- L1 Transaction Hash
- L1 Transaction Origin
- Gas Limit

### Changes
- Created a new top-level route `/txs-enqueued` to display the L1 -> L2 transactions table.
- Added a new component `LatestL1L2TransactionsTable` that renders the transactions in a table format.
- Updated the `fetchLatestL1L2Transactions` function to return 50 placeholder transactions.
#### In Progress - I will improve this by tomorrow
- Included links and icons for external and internal navigation:
  - Links to block explorer for L1 block number, L1 transaction hash, and L1 transaction origin.
  - Internal links for L2 transaction hash.
- Adjusted table styling to ensure better readability and alignment of icons.

### Notes
- Placeholder data is used for development. Integration with the real API is in progress.
- This PR does not include pagination; it will be implemented in a separate issue.

### Screenshots
<img width="1491" alt="image" src="https://github.com/walnuthq/op-scan/assets/75222804/456ef6c2-8b8e-44e1-b0ef-2c738cdd3223">
