### PR TITLE
feat: Implement latest blocks page

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.0",
     "@radix-ui/react-dropdown-menu": "^2.1.0",
+    "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.0",
     "class-variance-authority": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.0
         version: 2.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-progress':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.3.3)(react@18.3.1)
@@ -454,6 +457,19 @@ packages:
 
   '@radix-ui/react-primitive@2.0.0':
     resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.0':
+    resolution: {integrity: sha512-aSzvnYpP725CROcxAOEBVZZSIQVQdHgBr2QQFKySsaD14u8dNT0batuXI+AAGDdAHfXH8rbnHmjYFqVJ21KkRg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2567,6 +2583,16 @@ snapshots:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-progress@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-roving-focus@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
@@ -3207,7 +3233,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.3(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -3235,7 +3261,7 @@ snapshots:
       enhanced-resolve: 5.17.0
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -3257,7 +3283,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.0
         version: 2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-progress':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.3.3)(react@18.3.1)
@@ -3340,9 +3343,9 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.5.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
-      eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.3(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
     optionalDependencies:
@@ -3368,8 +3371,8 @@ snapshots:
       debug: 4.3.5
       enhanced-resolve: 5.17.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.14.0
@@ -3391,7 +3394,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5

--- a/src/app/blocks/page.tsx
+++ b/src/app/blocks/page.tsx
@@ -1,0 +1,51 @@
+import { Suspense } from 'react';
+import BlocksPage from '@/components/pages/blocks';
+import { l2PublicClient } from '@/lib/chains';
+
+interface BlocksPageParams {
+  searchParams: { page?: string; latest?: string };
+}
+
+async function fetchBlockData(page: number, latestBlockNumber?: bigint) {
+  const blocksPerPage = 25;
+  if (!latestBlockNumber) {
+    latestBlockNumber = await l2PublicClient.getBlockNumber();
+  }
+
+  const totalBlocks = latestBlockNumber;
+  const totalPages = Math.ceil(Number(totalBlocks) / blocksPerPage);
+  const startBlock = totalBlocks - BigInt((page - 1) * blocksPerPage);
+  const endBlock = totalBlocks - BigInt(page * blocksPerPage) + BigInt(1);
+
+  return {
+    latestBlockNumber,
+    totalBlocks,
+    totalPages,
+    startBlock,
+    endBlock,
+    blocksPerPage,
+  };
+}
+
+export default async function Blocks({ searchParams }: BlocksPageParams) {
+  const page = parseInt(searchParams.page || '1', 10);
+  const latestBlockNumber = searchParams.latest ? BigInt(searchParams.latest) : undefined;
+  const data = await fetchBlockData(page, latestBlockNumber);
+
+  return (
+    <main className="p-4">
+      <Suspense fallback={<div className='w-full h-screen grid place-content-center text-primary'>Loading...</div>}>
+        <BlocksPage
+          searchParams={searchParams}
+          currentPage={page}
+          blocksPerPage={data.blocksPerPage}
+          latestBlockNumber={data.latestBlockNumber}
+          totalBlocks={data.totalBlocks}
+          totalPages={data.totalPages}
+          startBlock={data.startBlock}
+          endBlock={data.endBlock}
+        />
+      </Suspense>
+    </main>
+  );
+}

--- a/src/components/pages/blocks/index.tsx
+++ b/src/components/pages/blocks/index.tsx
@@ -43,6 +43,8 @@ export default function BlocksPage({
             currentPage={currentPage}
             totalPages={totalPages}
             latestBlockNumber={latestBlockNumber.toString()}
+            totalBlocks={totalBlocks}
+            blocksPerPage={blocksPerPage}
           />
         </CardHeader>
         <LatestBlocksTable
@@ -64,6 +66,8 @@ export default function BlocksPage({
             currentPage={currentPage}
             totalPages={totalPages}
             latestBlockNumber={latestBlockNumber.toString()}
+            totalBlocks={totalBlocks}
+            blocksPerPage={blocksPerPage}
           />
         </CardFooter>
       </Card>

--- a/src/components/pages/blocks/index.tsx
+++ b/src/components/pages/blocks/index.tsx
@@ -1,0 +1,72 @@
+import Link from 'next/link';
+import { Card, CardDescription, CardFooter, CardHeader } from '@/components/ui/card';
+import LatestBlocksPagination from '@/components/pages/blocks/latest-blocks-pagination';
+import LatestBlocksTable from '@/components/pages/blocks/latest-blocks-table';
+
+interface BlocksPageProps {
+  searchParams: { page?: string; latest?: string };
+  currentPage: number;
+  blocksPerPage: number;
+  latestBlockNumber: bigint;
+  totalBlocks: bigint;
+  totalPages: number;
+  startBlock: bigint;
+  endBlock: bigint;
+}
+
+export default function BlocksPage({
+  searchParams,
+  currentPage,
+  blocksPerPage,
+  latestBlockNumber,
+  totalBlocks,
+  totalPages,
+  startBlock,
+  endBlock,
+}: BlocksPageProps) {
+  return (
+    <main>
+      <h2 className="mt-10 scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight transition-colors first:mt-0">
+        Blocks
+      </h2>
+      <Card className="mt-8">
+        <CardHeader className="flex flex-col md:flex-row justify-start md:justify-between items-start md:items-center p-4">
+          <div>
+            <p className="text-sm pb-2">
+              Total of {totalBlocks.toLocaleString() || 'fetching...'} blocks
+            </p>
+            <p className="text-xs block-diff">
+              (Showing blocks between #{startBlock.toString()} to #{endBlock.toString()})
+            </p>
+          </div>
+          <LatestBlocksPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            latestBlockNumber={latestBlockNumber.toString()}
+          />
+        </CardHeader>
+        <LatestBlocksTable
+          latestBlockNumber={latestBlockNumber}
+          currentPage={currentPage}
+          blocksPerPage={blocksPerPage}
+        />
+        <CardFooter className="flex flex-col md:flex-row justify-start md:justify-between items-start md:items-center p-4">
+          <div className="text-sm whitespace-nowrap">
+            Latest block number:{' '}
+            <Link
+              href={`/block/${latestBlockNumber}`}
+              className="text-primary hover:brightness-150"
+            >
+              {latestBlockNumber.toString()}
+            </Link>
+          </div>
+          <LatestBlocksPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            latestBlockNumber={latestBlockNumber.toString()}
+          />
+        </CardFooter>
+      </Card>
+    </main>
+  );
+}

--- a/src/components/pages/blocks/latest-blocks-pagination.tsx
+++ b/src/components/pages/blocks/latest-blocks-pagination.tsx
@@ -5,6 +5,8 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 interface LatestBlocksPaginationProps {
   currentPage: number;
   totalPages: number;
+  totalBlocks: bigint;
+  blocksPerPage: number;
   latestBlockNumber: string;
 }
 
@@ -12,7 +14,10 @@ export default function LatestBlocksPagination({
   currentPage,
   totalPages,
   latestBlockNumber,
+  totalBlocks,
+  blocksPerPage
 }: LatestBlocksPaginationProps) {
+  const lastPage = Math.ceil(Number(totalBlocks) / blocksPerPage);
   return (
     <section className="flex justify-center items-center space-x-1 mt-4 w-fit">
       <Button asChild className="bg-transparent text-xs text-primary hover:text-white border border-border w-fit h-fit p-2">
@@ -36,7 +41,7 @@ export default function LatestBlocksPagination({
         </Button>
       )}
       <Button asChild className="bg-transparent text-xs text-primary hover:text-white border border-border w-fit h-fit p-2">
-        <Link href={`/blocks?page=${totalPages}&latest=${latestBlockNumber}`}>Last</Link>
+        <Link href={`/blocks?page=${lastPage}&latest=${latestBlockNumber}`}>Last</Link>
       </Button>
     </section>
   );

--- a/src/components/pages/blocks/latest-blocks-pagination.tsx
+++ b/src/components/pages/blocks/latest-blocks-pagination.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface LatestBlocksPaginationProps {
+  currentPage: number;
+  totalPages: number;
+  latestBlockNumber: string;
+}
+
+export default function LatestBlocksPagination({
+  currentPage,
+  totalPages,
+  latestBlockNumber,
+}: LatestBlocksPaginationProps) {
+  return (
+    <section className="flex justify-center items-center space-x-1 mt-4 w-fit">
+      <Button asChild className="bg-transparent text-xs text-primary hover:text-white border border-border w-fit h-fit p-2">
+        <Link href={`/blocks?page=1&latest=${latestBlockNumber}`}>First</Link>
+      </Button>
+      {currentPage > 1 && (
+        <Button asChild className="bg-transparent text-primary hover:text-white border border-border w-fit h-fit p-2">
+          <Link href={`/blocks?page=${currentPage - 1}&latest=${latestBlockNumber}`}>
+            <ChevronLeft size={16} />
+          </Link>
+        </Button>
+      )}
+      <Button asChild className="bg-transparent text-xs text-primary cursor-default hover:bg-transparent hover:brightness-150 border border-border w-fit h-fit p-2">
+        <span>Page {currentPage} of {totalPages}</span>
+      </Button>
+      {currentPage < totalPages && (
+        <Button asChild className="bg-transparent text-primary hover:text-white border border-border w-fit h-fit p-2">
+          <Link href={`/blocks?page=${currentPage + 1}&latest=${latestBlockNumber}`}>
+            <ChevronRight size={16} />
+          </Link>
+        </Button>
+      )}
+      <Button asChild className="bg-transparent text-xs text-primary hover:text-white border border-border w-fit h-fit p-2">
+        <Link href={`/blocks?page=${totalPages}&latest=${latestBlockNumber}`}>Last</Link>
+      </Button>
+    </section>
+  );
+}

--- a/src/components/pages/blocks/latest-blocks-table.tsx
+++ b/src/components/pages/blocks/latest-blocks-table.tsx
@@ -1,0 +1,112 @@
+import Link from 'next/link';
+import { l2PublicClient } from "@/lib/chains";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { formatTimestamp } from "@/lib/utils";
+import { Progress } from '@/components/ui/progress';
+
+interface LatestBlocksTableProps {
+  latestBlockNumber: bigint;
+  currentPage: number;
+  blocksPerPage: number;
+}
+
+async function fetchBlocks(latestBlockNumber: bigint, currentPage: number, blocksPerPage: number) {
+  const startBlock = latestBlockNumber - BigInt((currentPage - 1) * blocksPerPage);
+  const blocks = await Promise.all(
+    Array.from({ length: blocksPerPage }, (_, i) =>
+      l2PublicClient.getBlock({ blockNumber: startBlock - BigInt(i) })
+    )
+  );
+  return blocks;
+}
+
+function formatGas(value: bigint, total?: bigint) {
+  const formattedValue = value.toLocaleString();
+  if (total) {
+    const percentage = ((Number(value) / Number(total)) * 100).toFixed(2);
+    return { formattedValue, percentage };
+  }
+  return { formattedValue };
+}
+
+export default async function LatestBlocksTable({
+  latestBlockNumber,
+  currentPage,
+  blocksPerPage,
+}: LatestBlocksTableProps) {
+  const blocks = await fetchBlocks(latestBlockNumber, currentPage, blocksPerPage);
+
+  return (
+    <TooltipProvider>
+      <Table className='table-auto md:table-fixed'>
+        <TableHeader>
+          <TableRow className='text-primary-foreground'>
+            <TableHead className='md:w-1/6'>Block</TableHead>
+            <TableHead className='md:w-1/6 text-primary'>Timestamp</TableHead>
+            <TableHead className='md:w-1/6'>Txn</TableHead>
+            <TableHead className='md:w-1/6'>Gas Used</TableHead>
+            <TableHead className='md:w-1/6'>Gas Limit</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {blocks.map((block) => (
+            <TableRow key={block.number.toString()}>
+              <TableCell>
+                <Link href={`/block/${block.number.toString()}`} className="text-primary hover:brightness-150">
+                  {block.number.toString()}
+                </Link>
+              </TableCell>
+              <TableCell className='whitespace-nowrap'>
+                <Tooltip>
+                  <TooltipTrigger>
+                    {formatTimestamp(block.timestamp, false)}
+                  </TooltipTrigger>
+                  <TooltipContent className='text-xs'>
+                    {new Date(Number(block.timestamp) * 1000).toUTCString()}
+                  </TooltipContent>
+                </Tooltip>
+              </TableCell>
+              <TableCell>
+                <Link href={`/block/${block.number.toString()}/txs`} className="text-primary hover:brightness-150">
+                  {block.transactions.length}
+                </Link>
+              </TableCell>
+              <TableCell className='md:max-w-[4rem]'>
+                <div className="flex items-center space-x-2">
+                  <span>{formatGas(block.gasUsed, block.gasLimit).formattedValue}</span>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <span className="text-xs text-gray-500">
+                        ({formatGas(block.gasUsed, block.gasLimit).percentage}%)
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent className="text-xs">
+                      Gas used in %
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <div className="progress-bar max-w-[4rem] h-[3px] bg-gray-200 mt-1">
+                  <Progress className='h-full rounded-none' value={(Number(block.gasUsed) / Number(block.gasLimit)) * 100} />
+                </div>
+              </TableCell>
+              <TableCell className='md:max-w-[4rem]'>{formatGas(block.gasLimit).formattedValue}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TooltipProvider>
+  );
+}

--- a/src/components/pages/blocks/latest-blocks-table.tsx
+++ b/src/components/pages/blocks/latest-blocks-table.tsx
@@ -25,8 +25,11 @@ interface LatestBlocksTableProps {
 
 async function fetchBlocks(latestBlockNumber: bigint, currentPage: number, blocksPerPage: number) {
   const startBlock = latestBlockNumber - BigInt((currentPage - 1) * blocksPerPage);
+  const remainingBlocks = Number(startBlock + BigInt(1));
+  const blocksToFetch = Math.min(blocksPerPage, remainingBlocks);
+
   const blocks = await Promise.all(
-    Array.from({ length: blocksPerPage }, (_, i) =>
+    Array.from({ length: blocksToFetch }, (_, i) =>
       l2PublicClient.getBlock({ blockNumber: startBlock - BigInt(i) })
     )
   );

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }


### PR DESCRIPTION
 closes #19   

#  Implemented paginated list of latest blocks with detailed information

## Features Implemented

- Display a table of the latest blocks using the shadcn/ui Table component.
- Each row in the table shows:
  - Block number (with a link to the block details page).
  - Timestamp (with tooltip showing the exact UTC time).
  - Transaction count (with a link to the block transactions page).
  - Gas used (with percentage against the gas limit).
  - Gas limit.
- Added a progress bar for gas used percentage using the shadcn/ui Progress component.
- Implemented pagination to navigate through the block history, displaying 25 blocks per page.
- The latest block number is fetched on the first page load and used as a reference for subsequent page navigation to ensure consistent pagination.

## Pagination Details

- Navigating to `/blocks` displays blocks 100 to 76.
- Navigating to `/blocks?p=2` displays blocks 75 to 51.
- Navigating to `/blocks?p=3` displays blocks 50 to 26.
- The latest block number is fetched using `viem getBlockNumber` if not provided as a query parameter.

## Implementation Details

- Used NextJS best practices for handling query parameters and data fetching.
- Server-side data fetching using React Server Components and `getServerSideProps`.
- Pagination is handled server-side using the `searchParams` parameter

## Screenshot Desktop
![image](https://github.com/walnuthq/op-scan/assets/60315147/50940c89-3ace-4a26-8cc9-a052e0509e28)

## Screenshot Mobile
![image](https://github.com/walnuthq/op-scan/assets/60315147/a0b7a633-2cb1-49e1-a3c3-334e11bbed4e)


Please review the changes and provide feedback. Thank you .
