### PR TITLE
Fetch Block Transactions from Database

### DIFF
--- a/src/components/pages/block-txs/fetch-block-transactions.ts
+++ b/src/components/pages/block-txs/fetch-block-transactions.ts
@@ -1,0 +1,81 @@
+import { l2PublicClient } from "@/lib/chains";
+import {
+  fromViemTransactionWithReceipt,
+  TransactionWithReceipt,
+  fromPrismaTransactionWithReceipt,
+} from "@/lib/types";
+import { loadFunctions } from "@/lib/signatures";
+import { prisma } from "@/lib/prisma";
+
+type FetchBlockTransactionsReturnType = {
+  transactions: TransactionWithReceipt[];
+};
+
+const fetchBlockTransactionsFromDatabase = async (
+  blockNumber: bigint,
+): Promise<FetchBlockTransactionsReturnType> => {
+  const transactions = await prisma.transaction.findMany({
+    where: { blockNumber },
+    include: { receipt: true },
+  });
+  if (!transactions || transactions.length === 0) {
+    return fetchBlockTransactionsFromJsonRpc(blockNumber);
+  }
+  const detailedTransactions = await Promise.all(
+    transactions.map(async (transaction) => {
+      if (!transaction.receipt) {
+        return null;
+      }
+      const signature = await loadFunctions(transaction.input.slice(0, 10));
+      return fromPrismaTransactionWithReceipt(
+        transaction,
+        transaction.receipt,
+        signature,
+      );
+    }),
+  ).then((results) => results.filter((tx) => tx !== null));
+  return {
+    transactions: detailedTransactions,
+  };
+};
+
+const fetchBlockTransactionsFromJsonRpc = async (
+  blockNumber: bigint,
+): Promise<FetchBlockTransactionsReturnType> => {
+  const block = await l2PublicClient.getBlock({
+    blockNumber,
+    includeTransactions: true,
+  });
+  if (!block) {
+    return {
+      transactions: [],
+    };
+  }
+  const [receipts, signatures] = await Promise.all([
+    Promise.all(
+      block.transactions.map(({ hash }) =>
+        l2PublicClient.getTransactionReceipt({ hash }),
+      ),
+    ),
+    Promise.all(
+      block.transactions.map(({ input }) => loadFunctions(input.slice(0, 10))),
+    ),
+  ]);
+  const detailedTransactions = block.transactions.map((transaction, i) =>
+    fromViemTransactionWithReceipt(
+      transaction,
+      receipts[i],
+      block.timestamp,
+      signatures[i],
+    ),
+  );
+  return {
+    transactions: detailedTransactions,
+  };
+};
+
+const fetchBlockTransactions = process.env.DATABASE_URL
+  ? fetchBlockTransactionsFromDatabase
+  : fetchBlockTransactionsFromJsonRpc;
+
+export default fetchBlockTransactions;


### PR DESCRIPTION
Closes #54 
### Description

This PR implements the functionality to fetch block transactions either from the database or via JSON-RPC, ensuring consistency in the returned data, this is configured using an already existing environment variable `DATABASE_URL` and complies with the design pattern implemented in the tx details page. The changes include creating a new helper function for fetching block transactions and modifying the `index.tsx` to utilize this new function.

### Changes

1. **Created `fetch-block-transactions.ts`**:
   - Added a helper function to fetch block transactions either from the database or via JSON-RPC.
   - Ensured the consistency of returned  transaction details.

2. **Modified `index.tsx`**:
   - Updated the component to use the new `fetchBlockTransactions` function.
   - Displayed the fetched transactions in a table format.
   
### Testing
   - Verified the functionality by fetching transactions from both the database and JSON-RPC and verifying the consistency of their data.
   
 ### Screenshots
 **Normal scenario**
 
![database_json_prc](https://github.com/user-attachments/assets/2b21d677-d76e-470e-886a-56ff764ca6a0)

**Fallback scenario**

![database_json_prc_fallback](https://github.com/user-attachments/assets/3492060a-8be0-42a7-8d57-28481e9fadef)

