### PR TITLE
feat: Copy button next to addresses

### DIFF
--- a/src/components/lib/copy-button.tsx
+++ b/src/components/lib/copy-button.tsx
@@ -8,29 +8,47 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-const CopyButton = ({ content, copy }: { content: string; copy: string }) => {
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const CopyButton = ({
+  content,
+  copy,
+}: {
+  className?: string;
+  content: string;
+  copy: string;
+}) => {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const copyText = async () => {
+    setOpen(true);
     await navigator.clipboard.writeText(copy);
     setCopied(true);
-    setTimeout(() => setCopied(false), 1000);
+    await sleep(1000);
+    setOpen(false);
+    await sleep(100);
+    setCopied(false);
   };
   return (
-    <TooltipProvider>
-      <Tooltip delayDuration={100} open={open || copied} onOpenChange={setOpen}>
-        <TooltipTrigger className="cursor-pointer text-muted-foreground hover:text-primary hover:brightness-150">
-          {copied ? (
-            <Check className="size-4" />
-          ) : (
-            <Copy className="size-4" onClick={copyText} />
-          )}
-        </TooltipTrigger>
-        <TooltipContent>
-          <p>{copied ? "Copied!" : content}</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <div className="mx-3 flex">
+      <TooltipProvider>
+        <Tooltip delayDuration={100} open={open} onOpenChange={setOpen}>
+          <TooltipTrigger
+            className="text-muted-foreground hover:text-primary hover:brightness-150"
+            onClick={copied ? undefined : copyText}
+          >
+            {copied ? (
+              <Check className="size-4" />
+            ) : (
+              <Copy className="size-4" />
+            )}
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{copied ? "Copied!" : content}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
   );
 };
 

--- a/src/components/pages/block-txs/block-txs-table-row.tsx
+++ b/src/components/pages/block-txs/block-txs-table-row.tsx
@@ -3,6 +3,7 @@ import { TransactionWithReceipt } from "@/lib/types";
 import { formatTimestamp, formatEther, formatGwei } from "@/lib/utils";
 import { TableRow, TableCell } from "@/components/ui/table";
 import TxMethodBadge from "@/components/lib/tx-method-badge";
+import CopyButton from "@/components/lib/copy-button";
 
 const BlockTxsTableRow = ({
   transaction,
@@ -16,13 +17,19 @@ const BlockTxsTableRow = ({
   const { distance, utc } = formatTimestamp(transaction.timestamp);
   return (
     <TableRow>
-      <TableCell className="max-w-40 truncate text-primary hover:brightness-150">
-        <Link
-          href={`/tx/${transaction.hash}`}
-          className="text-sm font-medium leading-none"
-        >
-          {transaction.hash}
-        </Link>
+      <TableCell className="max-w-40">
+        <div className="flex">
+          <Link
+            href={`/tx/${transaction.hash}`}
+            className="truncate text-sm font-medium leading-none text-primary hover:brightness-150"
+          >
+            {transaction.hash}
+          </Link>
+          <CopyButton
+            content="Copy Hash to clipboard"
+            copy={transaction.hash}
+          />
+        </div>
       </TableCell>
       <TableCell>
         <TxMethodBadge
@@ -31,21 +38,33 @@ const BlockTxsTableRow = ({
         />
       </TableCell>
       <TableCell>{timestampFormattedAsDate ? utc : distance}</TableCell>
-      <TableCell className="max-w-40 truncate text-primary hover:brightness-150">
-        <Link
-          href={`/address/${transaction.from}`}
-          className="text-sm font-medium leading-none"
-        >
-          {transaction.from}
-        </Link>
+      <TableCell className="max-w-40">
+        <div className="flex">
+          <Link
+            href={`/address/${transaction.from}`}
+            className="truncate text-sm font-medium leading-none text-primary hover:brightness-150"
+          >
+            {transaction.from}
+          </Link>
+          <CopyButton
+            content="Copy Address to clipboard"
+            copy={transaction.from}
+          />
+        </div>
       </TableCell>
-      <TableCell className="max-w-40 truncate text-primary hover:brightness-150">
-        <Link
-          href={`/address/${transaction.to}`}
-          className="text-sm font-medium leading-none"
-        >
-          {transaction.to}
-        </Link>
+      <TableCell className="max-w-40">
+        <div className="flex">
+          <Link
+            href={`/address/${transaction.to}`}
+            className="truncate text-sm font-medium leading-none text-primary hover:brightness-150"
+          >
+            {transaction.to}
+          </Link>
+          <CopyButton
+            content="Copy Address to clipboard"
+            copy={transaction.to ?? ""}
+          />
+        </div>
       </TableCell>
       <TableCell>{formatEther(transaction.value, 15)} ETH</TableCell>
       <TableCell>

--- a/src/components/pages/block/block-details.tsx
+++ b/src/components/pages/block/block-details.tsx
@@ -6,6 +6,7 @@ import TimestampListItem from "@/components/lib/timestamp-list-item";
 import { Block } from "@/lib/types";
 import BlockHeight from "@/components/pages/block/block-height";
 import BlockExtraData from "@/components/pages/block/block-extra-data";
+import CopyButton from "@/components/lib/copy-button";
 
 const BlockDetails = ({ block }: { block: Block }) => (
   <dl>
@@ -33,7 +34,10 @@ const BlockDetails = ({ block }: { block: Block }) => (
     </DescriptionListItem>
     <BlockExtraData extraData={block.extraData} />
     <Separator />
-    <DescriptionListItem title="Hash">{block.hash}</DescriptionListItem>
+    <DescriptionListItem title="Hash">
+      {block.hash}
+      <CopyButton content="Copy Hash to clipboard" copy={block.hash} />
+    </DescriptionListItem>
     <DescriptionListItem title="Parent Hash">
       <Link
         href={`/block/${block.parentHash}`}
@@ -41,6 +45,10 @@ const BlockDetails = ({ block }: { block: Block }) => (
       >
         {block.parentHash}
       </Link>
+      <CopyButton
+        content="Copy Parent Hash to clipboard"
+        copy={block.parentHash}
+      />
     </DescriptionListItem>
   </dl>
 );

--- a/src/components/pages/home/latest-transactions.tsx
+++ b/src/components/pages/home/latest-transactions.tsx
@@ -34,7 +34,7 @@ const LatestTransaction = ({ transaction }: { transaction: Transaction }) => (
         <div className="flex items-center gap-1">
           From{" "}
           <AddressLink
-            addressClassName={"truncate max-w-36 md:max-w-48 xl:max-w-36"}
+            addressClassName="truncate max-w-36 md:max-w-48 xl:max-w-36"
             address={transaction.from}
             href={`/address/${transaction.from}`}
           >
@@ -44,7 +44,7 @@ const LatestTransaction = ({ transaction }: { transaction: Transaction }) => (
         <div className="flex items-center gap-1">
           To{" "}
           <AddressLink
-            addressClassName={"truncate max-w-36 md:max-w-48 xl:max-w-36"}
+            addressClassName="truncate max-w-36 md:max-w-48 xl:max-w-36"
             address={transaction.to}
             href={`/address/${transaction.to}`}
           >

--- a/src/components/pages/tx/transaction-details.tsx
+++ b/src/components/pages/tx/transaction-details.tsx
@@ -14,6 +14,7 @@ import TransactionTo from "@/components/pages/tx/transaction-to";
 import TransactionERC20Transfers from "@/components/pages/tx/transaction-erc20-transfers";
 import TransactionOtherAttributes from "@/components/pages/tx/transaction-other-attributes";
 import TransactionInput from "@/components/pages/tx/transaction-input";
+import CopyButton from "@/components/lib/copy-button";
 
 const TransactionDetails = ({
   transaction,
@@ -29,6 +30,7 @@ const TransactionDetails = ({
   <dl>
     <DescriptionListItem title="Transaction Hash">
       {transaction.hash}
+      <CopyButton content="Copy TxHash to clipboard" copy={transaction.hash} />
     </DescriptionListItem>
     <DescriptionListItem title="Status">
       <TxStatusBadge success={transaction.receipt.status === "success"} />

--- a/src/components/pages/tx/transaction-from.tsx
+++ b/src/components/pages/tx/transaction-from.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Address } from "viem";
 import DescriptionListItem from "@/components/lib/description-list-item";
+import CopyButton from "@/components/lib/copy-button";
 
 const TransactionFrom = ({ from }: { from: Address }) => (
   <DescriptionListItem title="From">
@@ -10,6 +11,7 @@ const TransactionFrom = ({ from }: { from: Address }) => (
     >
       {from}
     </Link>
+    <CopyButton content="Copy Address to clipboard" copy={from} />
   </DescriptionListItem>
 );
 

--- a/src/components/pages/tx/transaction-to.tsx
+++ b/src/components/pages/tx/transaction-to.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { CircleCheck, CircleX } from "lucide-react";
 import { TransactionWithReceipt } from "@/lib/types";
 import DescriptionListItem from "@/components/lib/description-list-item";
+import CopyButton from "@/components/lib/copy-button";
 
 const TransactionTo = ({
   transaction,
@@ -21,6 +22,7 @@ const TransactionTo = ({
       >
         {transaction.to}
       </Link>
+      <CopyButton content="Copy Address to clipboard" copy={transaction.to} />
       {transaction.input !== "0x" && (
         <>
           {transaction.receipt.status === "success" ? (

--- a/src/components/pages/txs-enqueued/latest-txs-enqueued-table-row.tsx
+++ b/src/components/pages/txs-enqueued/latest-txs-enqueued-table-row.tsx
@@ -4,6 +4,7 @@ import { formatTimestamp, formatGas } from "@/lib/utils";
 import { TableRow, TableCell } from "@/components/ui/table";
 import { l1Chain } from "@/lib/chains";
 import { SquareArrowOutUpRight } from "lucide-react";
+import CopyButton from "@/components/lib/copy-button";
 
 const LatestTxsEnqueuedTableRow = ({
   transactionEnqueued,
@@ -26,45 +27,58 @@ const LatestTxsEnqueuedTableRow = ({
           <SquareArrowOutUpRight className="ml-1 size-4" />
         </a>
       </TableCell>
-      <TableCell>
-        <div className="max-w-40 truncate text-primary hover:brightness-150">
+      <TableCell className="max-w-40">
+        <div className="flex">
           <Link
-            className="text-sm font-medium leading-none"
             href={`/tx/${transactionEnqueued.l2TxHash}`}
+            className="truncate text-sm font-medium leading-none text-primary hover:brightness-150"
           >
             {transactionEnqueued.l2TxHash}
           </Link>
+          <CopyButton
+            content="Copy Hash to clipboard"
+            copy={transactionEnqueued.l2TxHash}
+          />
         </div>
       </TableCell>
       <TableCell suppressHydrationWarning>
         {timestampFormattedAsDate ? utc : distance}
       </TableCell>
-      <TableCell>
-        <a
-          className="flex items-center text-primary hover:brightness-150"
-          href={`${l1Chain.blockExplorers.default.url}/tx/${transactionEnqueued.l1TxHash}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <span className="max-w-40 truncate">
-            {transactionEnqueued.l1TxHash}
-          </span>
-          <SquareArrowOutUpRight className="ml-1 size-4" />
-        </a>
+      <TableCell className="max-w-40">
+        <div className="flex text-sm">
+          <a
+            className="flex items-center truncate text-primary hover:brightness-150"
+            href={`${l1Chain.blockExplorers.default.url}/tx/${transactionEnqueued.l2TxHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span className="truncate">{transactionEnqueued.l2TxHash}</span>
+            <SquareArrowOutUpRight className="ml-1 h-4 w-4 flex-shrink-0" />
+          </a>
+          <CopyButton
+            content="Copy Hash to clipboard"
+            copy={transactionEnqueued.l2TxHash}
+          />
+        </div>
       </TableCell>
-      <TableCell>
-        <a
-          className="flex items-center text-primary hover:brightness-150"
-          href={`${l1Chain.blockExplorers.default.url}/address/${transactionEnqueued.l1TxOrigin}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <span className="max-w-40 truncate">
-            {transactionEnqueued.l1TxOrigin}
-          </span>
-          <SquareArrowOutUpRight className="ml-1 size-4" />
-        </a>
+      <TableCell className="max-w-40">
+        <div className="flex text-sm">
+          <a
+            className="flex items-center truncate text-primary hover:brightness-150"
+            href={`${l1Chain.blockExplorers.default.url}/address/${transactionEnqueued.l1TxOrigin}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span className="truncate">{transactionEnqueued.l1TxOrigin}</span>
+            <SquareArrowOutUpRight className="ml-1 h-4 w-4 flex-shrink-0" />
+          </a>
+          <CopyButton
+            content="Copy Hash to clipboard"
+            copy={transactionEnqueued.l1TxOrigin}
+          />
+        </div>
       </TableCell>
+
       <TableCell>{formatGas(transactionEnqueued.gasLimit).value}</TableCell>
     </TableRow>
   );

--- a/src/components/pages/txs/latest-txs-table-row.tsx
+++ b/src/components/pages/txs/latest-txs-table-row.tsx
@@ -3,6 +3,7 @@ import { TransactionWithReceipt } from "@/lib/types";
 import { formatTimestamp, formatEther, formatGwei } from "@/lib/utils";
 import { TableRow, TableCell } from "@/components/ui/table";
 import TxMethodBadge from "@/components/lib/tx-method-badge";
+import CopyButton from "@/components/lib/copy-button";
 
 const LatestTxsTableRow = ({
   transaction,
@@ -16,14 +17,18 @@ const LatestTxsTableRow = ({
   const { distance, utc } = formatTimestamp(transaction.timestamp);
   return (
     <TableRow>
-      <TableCell>
-        <div className="max-w-40 truncate text-primary hover:brightness-150">
+      <TableCell className="max-w-40">
+        <div className="flex">
           <Link
             href={`/tx/${transaction.hash}`}
-            className="text-sm font-medium leading-none"
+            className="truncate text-sm font-medium leading-none text-primary hover:brightness-150"
           >
             {transaction.hash}
           </Link>
+          <CopyButton
+            content="Copy Hash to clipboard"
+            copy={transaction.hash}
+          />
         </div>
       </TableCell>
       <TableCell>
@@ -43,23 +48,33 @@ const LatestTxsTableRow = ({
       <TableCell suppressHydrationWarning>
         {timestampFormattedAsDate ? utc : distance}
       </TableCell>
-      <TableCell>
-        <div className="max-w-40 truncate text-primary hover:brightness-150">
+      <TableCell className="max-w-40">
+        <div className="flex">
           <Link
             href={`/address/${transaction.from}`}
-            className="text-sm font-medium leading-none"
+            className="truncate text-sm font-medium leading-none text-primary hover:brightness-150"
           >
             {transaction.from}
           </Link>
+          <CopyButton
+            content="Copy Address to clipboard"
+            copy={transaction.from}
+          />
         </div>
       </TableCell>
-      <TableCell className="max-w-40 truncate text-primary hover:brightness-150">
-        <Link
-          href={`/address/${transaction.to}`}
-          className="text-sm font-medium leading-none"
-        >
-          {transaction.to}
-        </Link>
+      <TableCell className="max-w-40">
+        <div className="flex">
+          <Link
+            href={`/address/${transaction.to}`}
+            className="truncate text-sm font-medium leading-none text-primary hover:brightness-150"
+          >
+            {transaction.to}
+          </Link>
+          <CopyButton
+            content="Copy Address to clipboard"
+            copy={transaction.to ?? ""}
+          />
+        </div>
       </TableCell>
       <TableCell>{formatEther(transaction.value, 15)} ETH</TableCell>
       <TableCell>


### PR DESCRIPTION
### Feature: Copy Button Next to Addresses  |  [Issue #48](https://github.com/walnuthq/op-scan/issues/48)

-------------------------------------------------------------------------------------------------------------------------------------------

*Description*
Similar to Etherscan, we want a copy label next to addresses to make it simpler for people to copy those hashes. Once the copy button has been clicked, let's show a quick toast indicating the address has been copied.

*Changes - Refactor Copy Button*
  1. **Change the way the title of "Copied" and "Content" is displayed.**
    - *File:* copy-button.tsx
    - *Description:*  
    
      - Previously, there was a small visual bug where, upon clicking to copy, both messages appeared correctly. However, at the end, the "Content" message briefly reappeared. This small error has been fixed.
      - NOTE: I had to add the `<div class="mx-3 flex">` because otherwise, the icon wouldn't be centered or spaced with the other text.
      - (Thanks a lot for your solution to change the useEffect)

*Changes - Add Copy Button in some places*

  1. **Add Copy Button in `Transactions For Block`**
    - *File:* block-transactions-table-row.tsx
    - *Description:* 
      - The copy button was added in the columns for `Transaction Hash, From, and To`.
      - The structure of each `TableCell` had to be slightly modified because the truncate feature was not applied correctly, making it impossible to display the copy button. To resolve this, the code used correctly in other tables was reused.

  2. **Add Copy Button in `Block Details`**
    - *File:* block-details.tsx
    - *Description:* 
      - The copy button was added in `Hash and Parent Hash`.

  3. **Add Copy Button in `Transaction Details`**
    - *File:* transaction-details.tsx, transaction-from.tsx and transaction-to.tsx
    - *Description:* 
      - The copy button was added in `Transaction Hash, From and Interacted With (To)`.

  4. **Add Copy Button in `Latest Transactions`**
    - *File:* latest-txs-table-row.tsx
    - *Description:* 
      - The copy button was added in `Tx Hash, From and To`.

  5. **Add Copy Button in `L1 - L2 Transactions`**
    - *File:* latest-txs-enqueued-table-row.tsx
    - *Description:* 
      - The copy button was added in `L2 Tx Hash, L1 Tx Has and L1 Tx Origin`.

*Notes*
  1. All the positions where the copy buttons were placed were guided by EtherScan. If any need to be removed or added, please let me know, and I will gladly make the change.
  2. I removed all the curly braces in string props.
*Evidence*
  1. *Bug Fix in title of Copy Button*
![2024-07-31 13 39 48](https://github.com/user-attachments/assets/a096206c-adef-4488-b6c4-ebf6116159f0)

  3. *Transactions (Transaction Hash, From and To)*
![image](https://github.com/user-attachments/assets/5c860f2c-66c2-4b4f-bd78-3e5079e07dcc)

  4. *Block (hash and parent hash)*
![image](https://github.com/user-attachments/assets/638b8ab2-a424-4437-95e4-11d793b8f228)

  5. *Transaction Details (Transaction Details, From and Interacted With (To))*
![image](https://github.com/user-attachments/assets/01f256b8-cc65-437b-bd5f-2e3045b922fa)

  6. *Latest Transactions (Tx Hash, From and To)*
![image](https://github.com/user-attachments/assets/449abb90-46b3-4905-a06c-b9394af2fc20)

  7. *L1 - L2 Transactions (L2 Tx Hash, L1 Tx Has and L1 Tx Origin)*
![image](https://github.com/user-attachments/assets/6dac3b56-d289-4449-bf45-b972da082c3c)





